### PR TITLE
Configure headlamp service as LoadBalancer

### DIFF
--- a/roles/headlamp/defaults/main.yml
+++ b/roles/headlamp/defaults/main.yml
@@ -2,4 +2,6 @@
 headlamp_helm_chart_ref: /charts/headlamp
 headlamp_helm_release_name: headlamp
 headlamp_helm_release_namespace: kube-system
-headlamp_helm_values: {}
+headlamp_helm_values:
+  service:
+    type: LoadBalancer


### PR DESCRIPTION
Enable external access to headlamp service via port 80 by configuring the service type as LoadBalancer in the Ansible role defaults.