### PR TITLE
headlamp: add ServiceAccount and ClusterRoleBinding

### DIFF
--- a/roles/headlamp/tasks/main.yml
+++ b/roles/headlamp/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+- name: Apply headlamp ServiceAccount
+  kubernetes.core.k8s:
+    definition: "{{ lookup('template', 'serviceaccount.yml.j2') | from_yaml }}"
+    kubeconfig: /share/kubeconfig
+    state: present
+
+- name: Apply headlamp ClusterRoleBinding
+  kubernetes.core.k8s:
+    definition: "{{ lookup('template', 'clusterrolebinding.yml.j2') | from_yaml }}"
+    kubeconfig: /share/kubeconfig
+    state: present
+
 - name: Deploy headlamp
   kubernetes.core.helm:
     release_name: "{{ headlamp_helm_release_name }}"

--- a/roles/headlamp/templates/clusterrolebinding.yml.j2
+++ b/roles/headlamp/templates/clusterrolebinding.yml.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: headlamp-admin
+  namespace: {{ headlamp_helm_release_namespace }}

--- a/roles/headlamp/templates/serviceaccount.yml.j2
+++ b/roles/headlamp/templates/serviceaccount.yml.j2
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp-admin
+  namespace: {{ headlamp_helm_release_namespace }}


### PR DESCRIPTION
Creates headlamp-admin ServiceAccount in kube-system namespace with cluster-admin permissions to enable proper RBAC for headlamp deployment.

AI-assisted: Claude Code