### PR TITLE
Move cert-manager CRDs from roles/crds to roles/cert_manager

### DIFF
--- a/roles/cert_manager/defaults/main.yml
+++ b/roles/cert_manager/defaults/main.yml
@@ -1,4 +1,10 @@
 ---
+cert_manager_crds: true
+cert_manager_crds_helm_chart_ref: /charts/cert-manager-crds
+cert_manager_crds_helm_release_name: cert-manager-crds
+cert_manager_crds_helm_release_namespace: crds
+cert_manager_crds_helm_values: {}
+
 cert_manager_helm_chart_ref: /charts/cert-manager
 cert_manager_helm_release_name: cert-manager
 cert_manager_helm_release_namespace: certificates

--- a/roles/cert_manager/tasks/main.yml
+++ b/roles/cert_manager/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: Deploy cert-manager crds
+  kubernetes.core.helm:
+    release_name: "{{ cert_manager_crds_helm_release_name }}"
+    chart_ref: "{{ cert_manager_crds_helm_chart_ref }}"
+    release_namespace: "{{ cert_manager_crds_helm_release_namespace }}"
+    create_namespace: true
+    kubeconfig: /share/kubeconfig
+    wait: true
+    values: "{{ _cert_manager_crds_helm_values | combine(cert_manager_crds_helm_values, recursive=True) }}"
+  when: cert_manager_crds | bool
+
 - name: Deploy cert-manager
   kubernetes.core.helm:
     release_name: "{{ cert_manager_helm_release_name }}"

--- a/roles/cert_manager/vars/main.yml
+++ b/roles/cert_manager/vars/main.yml
@@ -1,2 +1,3 @@
 ---
+_cert_manager_crds_helm_values: {}
 _cert_manager_helm_values: {}

--- a/roles/crds/defaults/main.yml
+++ b/roles/crds/defaults/main.yml
@@ -1,10 +1,4 @@
 ---
-crds_cert_manager: true
-crds_cert_manager_helm_chart_ref: /charts/cert-manager-crds
-crds_cert_manager_helm_release_name: cert-manager-crds
-crds_cert_manager_helm_release_namespace: crds
-crds_cert_manager_helm_values: {}
-
 crds_mariadb_operator: true
 crds_mariadb_operator_helm_chart_ref: /charts/mariadb-operator-crds
 crds_mariadb_operator_helm_release_name: mariadb-operator-crds

--- a/roles/crds/tasks/main.yml
+++ b/roles/crds/tasks/main.yml
@@ -1,15 +1,4 @@
 ---
-- name: Deploy cert-manager crds
-  kubernetes.core.helm:
-    release_name: "{{ crds_cert_manager_helm_release_name }}"
-    chart_ref: "{{ crds_cert_manager_helm_chart_ref }}"
-    release_namespace: "{{ crds_cert_manager_helm_release_namespace }}"
-    create_namespace: true
-    kubeconfig: /share/kubeconfig
-    wait: true
-    values: "{{ _crds_cert_manager_helm_values | combine(crds_cert_manager_helm_values, recursive=True) }}"
-  when: crds_cert_manager | bool
-
 - name: Deploy mariadb-operator crds
   kubernetes.core.helm:
     release_name: "{{ crds_mariadb_operator_helm_release_name }}"

--- a/roles/crds/vars/main.yml
+++ b/roles/crds/vars/main.yml
@@ -1,5 +1,4 @@
 ---
-_crds_cert_manager_helm_values: {}
 _crds_mariadb_operator_helm_values: {}
 _crds_prometheus_operator_helm_values: {}
 _crds_yaook_operators_helm_values: {}


### PR DESCRIPTION
Consolidate cert-manager CRD deployment with the main cert-manager role to improve organization and maintainability. CRDs are now deployed before the main cert-manager installation within the same role.