### PR TITLE
Move mariadb-operator CRDs from roles/crds to roles/mariadb_operator

### DIFF
--- a/roles/crds/defaults/main.yml
+++ b/roles/crds/defaults/main.yml
@@ -1,10 +1,4 @@
 ---
-crds_mariadb_operator: true
-crds_mariadb_operator_helm_chart_ref: /charts/mariadb-operator-crds
-crds_mariadb_operator_helm_release_name: mariadb-operator-crds
-crds_mariadb_operator_helm_release_namespace: crds
-crds_mariadb_operator_helm_values: {}
-
 crds_prometheus_operator: true
 crds_prometheus_operator_helm_chart_ref: /charts/prometheus-operator-crds
 crds_prometheus_operator_helm_release_name: prometheus-operator-crds

--- a/roles/crds/tasks/main.yml
+++ b/roles/crds/tasks/main.yml
@@ -1,15 +1,4 @@
 ---
-- name: Deploy mariadb-operator crds
-  kubernetes.core.helm:
-    release_name: "{{ crds_mariadb_operator_helm_release_name }}"
-    chart_ref: "{{ crds_mariadb_operator_helm_chart_ref }}"
-    release_namespace: "{{ crds_mariadb_operator_helm_release_namespace }}"
-    create_namespace: true
-    kubeconfig: /share/kubeconfig
-    wait: true
-    values: "{{ _crds_mariadb_operator_helm_values | combine(crds_mariadb_operator_helm_values, recursive=True) }}"
-  when: crds_mariadb_operator | bool
-
 - name: Deploy prometheus operator crds
   kubernetes.core.helm:
     release_name: "{{ crds_prometheus_operator_helm_release_name }}"

--- a/roles/crds/vars/main.yml
+++ b/roles/crds/vars/main.yml
@@ -1,4 +1,3 @@
 ---
-_crds_mariadb_operator_helm_values: {}
 _crds_prometheus_operator_helm_values: {}
 _crds_yaook_operators_helm_values: {}

--- a/roles/mariadb_operator/defaults/main.yml
+++ b/roles/mariadb_operator/defaults/main.yml
@@ -4,6 +4,12 @@ mariadb_operator_image: "{{ container_registry_mariadb_operator }}/mariadb-opera
 # renovate: datasource=docker depName=docker-registry3.mariadb.com/mariadb-operator/mariadb-operator
 mariadb_operator_image_tag: "0.38.1"
 
+mariadb_operator_crds: true
+mariadb_operator_crds_helm_chart_ref: /charts/mariadb-operator-crds
+mariadb_operator_crds_helm_release_name: mariadb-operator-crds
+mariadb_operator_crds_helm_release_namespace: crds
+mariadb_operator_crds_helm_values: {}
+
 mariadb_operator_helm_chart_ref: /charts/mariadb-operator
 mariadb_operator_helm_release_name: mariadb-operator
 mariadb_operator_helm_release_namespace: mariadb-operator

--- a/roles/mariadb_operator/tasks/main.yml
+++ b/roles/mariadb_operator/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: Deploy mariadb-operator crds
+  kubernetes.core.helm:
+    release_name: "{{ mariadb_operator_crds_helm_release_name }}"
+    chart_ref: "{{ mariadb_operator_crds_helm_chart_ref }}"
+    release_namespace: "{{ mariadb_operator_crds_helm_release_namespace }}"
+    create_namespace: true
+    kubeconfig: /share/kubeconfig
+    wait: true
+    values: "{{ _mariadb_operator_crds_helm_values | combine(mariadb_operator_crds_helm_values, recursive=True) }}"
+  when: mariadb_operator_crds | bool
+
 - name: Deploy mariadb-operator
   kubernetes.core.helm:
     release_name: "{{ mariadb_operator_helm_release_name }}"

--- a/roles/mariadb_operator/vars/main.yml
+++ b/roles/mariadb_operator/vars/main.yml
@@ -1,5 +1,6 @@
 # source: https://raw.githubusercontent.com/mariadb-operator/mariadb-operator/main/deploy/charts/mariadb-operator/values.yaml
 ---
+_mariadb_operator_crds_helm_values: {}
 _mariadb_operator_helm_values:
   nameOverride: ""
   fullnameOverride: ""


### PR DESCRIPTION
This change relocates the mariadb-operator CRDs deployment from the generic crds role to the specific mariadb_operator role, following the same pattern as cert-manager CRDs. The mariadb-operator CRDs are now deployed as part of the mariadb_operator role setup.