### PR TITLE
Move yaook-operators CRDs from roles/crds to roles/yaook_operators

### DIFF
--- a/roles/crds/defaults/main.yml
+++ b/roles/crds/defaults/main.yml
@@ -4,9 +4,3 @@ crds_prometheus_operator_helm_chart_ref: /charts/prometheus-operator-crds
 crds_prometheus_operator_helm_release_name: prometheus-operator-crds
 crds_prometheus_operator_helm_release_namespace: crds
 crds_prometheus_operator_helm_values: {}
-
-crds_yaook_operators: true
-crds_yaook_operators_helm_chart_ref: /charts/crds
-crds_yaook_operators_helm_release_name: yaook-operators-crds
-crds_yaook_operators_helm_release_namespace: crds
-crds_yaook_operators_helm_values: {}

--- a/roles/crds/tasks/main.yml
+++ b/roles/crds/tasks/main.yml
@@ -9,14 +9,3 @@
     wait: true
     values: "{{ _crds_prometheus_operator_helm_values | combine(crds_prometheus_operator_helm_values, recursive=True) }}"
   when: crds_prometheus_operator | bool
-
-- name: Deploy yaook operators crds
-  kubernetes.core.helm:
-    release_name: "{{ crds_yaook_operators_helm_release_name }}"
-    chart_ref: "{{ crds_yaook_operators_helm_chart_ref }}"
-    release_namespace: "{{ crds_yaook_operators_helm_release_namespace }}"
-    create_namespace: true
-    kubeconfig: /share/kubeconfig
-    wait: true
-    values: "{{ _crds_yaook_operators_helm_values | combine(crds_yaook_operators_helm_values, recursive=True) }}"
-  when: crds_yaook_operators | bool

--- a/roles/crds/vars/main.yml
+++ b/roles/crds/vars/main.yml
@@ -1,3 +1,2 @@
 ---
 _crds_prometheus_operator_helm_values: {}
-_crds_yaook_operators_helm_values: {}

--- a/roles/yaook_operators/defaults/main.yml
+++ b/roles/yaook_operators/defaults/main.yml
@@ -1,4 +1,10 @@
 ---
+yaook_operators_crds: true
+yaook_operators_crds_helm_chart_ref: /charts/crds
+yaook_operators_crds_helm_release_name: yaook-operators-crds
+yaook_operators_crds_helm_release_namespace: crds
+yaook_operators_crds_helm_values: {}
+
 yaook_operators_helm_release_namespace: yaook-operators
 
 yaook_operators_cds_helm_release_name: yaook-cds-operator

--- a/roles/yaook_operators/tasks/main.yml
+++ b/roles/yaook_operators/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: Deploy yaook operators crds
+  kubernetes.core.helm:
+    release_name: "{{ yaook_operators_crds_helm_release_name }}"
+    chart_ref: "{{ yaook_operators_crds_helm_chart_ref }}"
+    release_namespace: "{{ yaook_operators_crds_helm_release_namespace }}"
+    create_namespace: true
+    kubeconfig: /share/kubeconfig
+    wait: true
+    values: "{{ _yaook_operators_crds_helm_values | combine(yaook_operators_crds_helm_values, recursive=True) }}"
+  when: yaook_operators_crds | bool
+
 - name: Deploy cds-operator
   kubernetes.core.helm:
     release_name: "{{ yaook_operators_cds_helm_release_name }}"

--- a/roles/yaook_operators/vars/main.yml
+++ b/roles/yaook_operators/vars/main.yml
@@ -1,4 +1,5 @@
 ---
+_yaook_operators_crds_helm_values: {}
 _yaook_operators_cds_helm_values: {}
 _yaook_operators_cinder_helm_values: {}
 _yaook_operators_glance_helm_values: {}


### PR DESCRIPTION
This consolidates yaook operator CRDs with their corresponding operator deployments, following the same pattern as other operators in the codebase.