### PR TITLE
Fix rendering of versions.yml

### DIFF
--- a/files/src/render-versions.py
+++ b/files/src/render-versions.py
@@ -16,7 +16,7 @@ environment = jinja2.Environment(loader=loader)
 # render versions.yml
 
 template = environment.get_template("versions.yml.j2")
-result = template.render({"osism_kubernetes_version": versions["manager_version"]})
+result = template.render({"manager_version": versions["manager_version"]})
 
 with open("/ansible/group_vars/all/versions.yml", "w+") as fp:
     fp.write(result)


### PR DESCRIPTION
The variable passed for rendering of the versions.yml template did not match the one actually used in the template. This leads to the `osism_kubernetes_version` variable set to an empty string in the inventory.
The variable is used to define the container tag, which ultimately leads to an inability to pull the image.