### PR TITLE
Rename repository from cfg-generics -> generics

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -80,7 +80,7 @@ useradd -l -g dragon -G docker -u "$USER_ID" -m -d /ansible dragon
 git clone https://github.com/osism/release /release
 
 # prepare project repository
-git clone https://github.com/osism/cfg-generics /generics
+git clone https://github.com/osism/generics /generics
 
 if [ "$VERSION" != "latest" ]; then
   ( cd /release || exit; git fetch --all --force; git checkout "osism-kubernetes-$VERSION" )

--- a/zuul-playbooks/build.yml
+++ b/zuul-playbooks/build.yml
@@ -33,7 +33,7 @@
           set -x
 
           # This is a way to use this job also in other repositories
-          # (osism/cfg-generics, osism/defaults, ..). The assumption
+          # (osism/generics, osism/defaults, ..). The assumption
           # is that if no Containerfile is available, the job was executed
           # from one of the other repositories. There are probably more
           # elegant ways to solve this, but it is good enough for now.


### PR DESCRIPTION
## Summary
- `osism/cfg-generics` was renamed to `osism/generics`. Update the Containerfile `git clone` and the comment in `zuul-playbooks/build.yml`.
- GitHub's rename alias keeps the old URL working, so no behavior change is expected.

## Test plan
- [ ] Image build succeeds; `/generics` is populated from `osism/generics`