### PR TITLE
build: drop redundant Python library pins

### DIFF
--- a/files/src/templates/requirements.txt.j2
+++ b/files/src/templates/requirements.txt.j2
@@ -4,5 +4,4 @@ ansible-core{{ ansible_core_version }}
 {% else %}
 ansible-core=={{ ansible_core_version }}
 {% endif %}
-ara=={{ osism_projects['ara'] }}
 osism=={{ osism_projects['osism'] }}


### PR DESCRIPTION
Remove the `ara` pin from `files/src/templates/requirements.txt.j2`.
The `ara` library is in `python-osism`'s `install_requires`; when the
container installs `osism==X.Y.Z`, `ara` arrives as a hard transitive
constraint, making the per-container pin redundant. Renovate monitoring
the template independently creates a race condition where a version bump
in either side would break the container build.

## Test plan

- [ ] `container-image-osism-kubernetes-build` passes

Related: [ceph-ansible #689](https://github.com/osism/container-image-ceph-ansible/pull/689), [osism-ansible #747](https://github.com/osism/container-image-osism-ansible/pull/747), [kolla-ansible #906](https://github.com/osism/container-image-kolla-ansible/pull/906), [osism/issues#1366](https://github.com/osism/issues/issues/1366)