### PR TITLE
ansible: drop obsolete osism-fqcn noqa on blocks

### DIFF
--- a/playbooks/kubernetes-k3s-upgrade.yml
+++ b/playbooks/kubernetes-k3s-upgrade.yml
@@ -19,7 +19,7 @@
 
     - name: Update node only if needed
       when: k3s_installed_version is version(k3s_version, '<')
-      block:  # noqa: osism-fqcn
+      block:
         - name: Download k3s binary
           become: true
           ansible.builtin.get_url:

--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check for PXE-booted system
-  block:  # noqa: osism-fqcn
+  block:
     - name: Check if system is PXE-booted
       ansible.builtin.command:
         cmd: cat /proc/cmdline

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -59,7 +59,7 @@
 
 - name: Verification
   when: not ansible_check_mode
-  block:  # noqa: osism-fqcn
+  block:
     - name: Detect Kubernetes version for label compatibility
       ansible.builtin.command:
         cmd: "{{ k3s_kubectl_binary | default('k3s kubectl') }} version --output=json"

--- a/roles/k3s_server_post/tasks/calico.yml
+++ b/roles/k3s_server_post/tasks/calico.yml
@@ -2,7 +2,7 @@
 - name: Deploy Calico to cluster
   when: ansible_hostname == hostvars[groups[group_name_master | default('master')][0]]['ansible_hostname']
   run_once: true
-  block:  # noqa: osism-fqcn
+  block:
     - name: Create manifests directory on first master
       ansible.builtin.file:
         path: /tmp/k3s
@@ -28,7 +28,7 @@
         mode: "0755"
 
     - name: Deploy or replace Tigera Operator
-      block:  # noqa: osism-fqcn
+      block:
         - name: Deploy Tigera Operator
           ansible.builtin.command:
             cmd: "{{ k3s_kubectl_binary | default('k3s kubectl') }} create -f /tmp/k3s/tigera-operator.yaml"
@@ -61,7 +61,7 @@
         label: "{{ item.type }}/{{ item.name }}"
 
     - name: Deploy Calico custom resources
-      block:  # noqa: osism-fqcn
+      block:
         - name: Deploy custom resources for Calico
           ansible.builtin.command:
             cmd: "{{ k3s_kubectl_binary | default('k3s kubectl') }} create -f /tmp/k3s/custom-resources.yaml"

--- a/roles/k3s_server_post/tasks/cilium.yml
+++ b/roles/k3s_server_post/tasks/cilium.yml
@@ -2,7 +2,7 @@
 - name: Deploy Cilium CNI
   run_once: true
   delegate_to: localhost
-  block:  # noqa: osism-fqcn
+  block:
     - name: Create tmp directory on first master
       ansible.builtin.file:
         path: /tmp/k3s
@@ -35,7 +35,7 @@
 
     - name: Check existing Cilium install
       when: cilium_installed.rc == 0
-      block:  # noqa: osism-fqcn
+      block:
         - name: Check Cilium version
           ansible.builtin.command: cilium version
           register: cilium_version
@@ -140,7 +140,7 @@
 
     - name: Configure Cilium BGP
       when: cilium_bgp
-      block:  # noqa: osism-fqcn
+      block:
         - name: Set _cilium_bgp_neighbors fact
           ansible.builtin.set_fact:
             _cilium_bgp_neighbors: "{{ lookup('community.general.merge_variables', '^cilium_bgp_neighbors__.+$', initial_value=cilium_bgp_neighbors, groups=cilium_bgp_neighbors_groups) }}"  # yamllint disable-line rule:line-length

--- a/roles/monitoring/tasks/config-openstack-exporter.yml
+++ b/roles/monitoring/tasks/config-openstack-exporter.yml
@@ -7,7 +7,7 @@
     group: "{{ operator_group }}"
     mode: 0750
 
-- name: Prepare helm chart values  # noqa: osism-fqcn
+- name: Prepare helm chart values
   block:
     - name: Read openstack exporter clouds.yml file content
       ansible.builtin.set_fact:


### PR DESCRIPTION
The custom `osism-fqcn` ansible-lint rule previously emitted spurious
violations on `block`/`rescue`/`always` constructs, which required
`# noqa: osism-fqcn` workarounds on plain block tasks.

osism/container-images#902 fixed the rule so it no longer flags these
constructs, and the updated `ansible-lint` image is now published. The
noqa annotations on these block constructs were all false-positives and
are now obsolete, so this change removes them (10 occurrences across 6
files).

This is part of the cleanup sweep tracked in osism/issues#1368.

Related-Bug: #1368