### PR TITLE
build: pin helm to 3.20.2 to avoid Helm 4

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -136,11 +136,14 @@ rm -rf /usr/share/mitogen/{tests,docs,.ci,.lgtm.yml,.travis.yml}
 rm /mitogen.tar.gz
 
 # install helm
+# Pin to 3.x: Helm 4 makes "helm plugin install" verify provenance by
+# default, which helm-diff does not ship, breaking the build. Stay on 3
+# until a deliberate, tested Helm 4 migration (3.x EOL 2026-11-11).
 curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor | tee /usr/share/keyrings/helm.gpg > /dev/null
 echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | tee /etc/apt/sources.list.d/helm-stable-debian.list
 apt-get update
 apt-get install --no-install-recommends -y \
-  helm
+  helm=3.20.2-1
 
 # install helm plugins
 helm plugin install https://github.com/databus23/helm-diff


### PR DESCRIPTION
## Problem

`osism-kubernetes-push` (nightly image build) started failing on
2026-06-09. The image installs helm **unpinned** from the buildkite apt
repo, so apt picks the highest available version. **Helm 4.2.0 landed in
that repo on 2026-06-08/09** and became the default — the 2026-06-08 build
got helm 3.x and passed; the 2026-06-09 build got `helm 4.2.0-1` and failed.
No code in this repo changed.

Helm 4's WebAssembly plugin overhaul makes `helm plugin install` **verify
plugin provenance by default** (HIP-0026:
https://helm.sh/community/hips/hip-0026/). `databus23/helm-diff` ships no
`.prov` provenance artifact, so the build aborts at the helm-diff plugin
install step:

```
Error: plugin source does not support verification. Use --verify=false to skip verification
ERROR: failed to build: failed to solve: ... exit code: 1
```

This is deterministic — a recheck will not clear it.

## Fix

Pin to `helm=3.20.2-1` (the latest 3.x served by the buildkite repo).
This restores the build with the known-good major version. Helm is core to
this image's runtime — ~15 roles deploy charts via `kubernetes.core.helm`
(cert_manager, rook, cloudnative_pg, mariadb_operator, monitoring, …) — so
the major bump should not be absorbed untested as a side effect of a CI fix.

The underlying defect is the unpinned install, which let a major version
arrive by accident; pinning also stops future silent drift.

## Follow-up (not in this PR)

Migrate to Helm 4 **deliberately and tested** before Helm 3 end of life —
tracked in #302. Per the official Helm 4 release announcement
(https://helm.sh/blog/helm-4-released/): **bug fixes until 2026-07-08,
security fixes until 2026-11-11.** The migration will need
`helm plugin install --verify=false` (or helm-diff shipping provenance)
plus validation of the deployment roles against Helm 4.

## Test notes

Not built locally (the image build only runs in CI). Verified that
`helm 3.20.2-1` is present in the buildkite apt index and that Helm 3 does
not verify plugins. CI on this PR is the real check.

## References

- HIP-0026 (Wasm plugin system): https://helm.sh/community/hips/hip-0026/
- Helm 4 released / Helm 3 EOL: https://helm.sh/blog/helm-4-released/
- Helm 4 migration follow-up: #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)