### PR TITLE
Apply the keycloak-operator CRDs from the role

### DIFF
--- a/roles/keycloak_operator/defaults/main.yml
+++ b/roles/keycloak_operator/defaults/main.yml
@@ -12,3 +12,13 @@ keycloak_operator_directory: /tmp/keycloak_operator
 keycloak_operator_template_directory: .
 
 keycloak_operator_namespace: keycloak
+
+keycloak_operator_crd_directory: "{{ role_path }}/files"
+
+keycloak_operator_crds:
+  - keycloaks.k8s.keycloak.org-v1.yml
+  - keycloakrealmimports.k8s.keycloak.org-v1.yml
+
+keycloak_operator_crd_names:
+  - keycloaks.k8s.keycloak.org
+  - keycloakrealmimports.k8s.keycloak.org

--- a/roles/keycloak_operator/tasks/crds.yml
+++ b/roles/keycloak_operator/tasks/crds.yml
@@ -1,0 +1,30 @@
+---
+- name: Apply keycloak-operator CRDs
+  # The CRDs must exist before the operator Deployment, otherwise the operator
+  # has nothing to reconcile. server_side_apply is required: these two files are
+  # ~205 KB and ~176 KB, and a client-side apply stores the full object in the
+  # last-applied-configuration annotation, which exceeds the metadata size limit.
+  kubernetes.core.k8s:
+    definition: "{{ lookup('file', keycloak_operator_crd_directory + '/' + item) | from_yaml }}"
+    kubeconfig: /share/kubeconfig
+    state: present
+    apply: true
+    server_side_apply:
+      field_manager: osism-keycloak-operator
+  loop: "{{ keycloak_operator_crds }}"
+
+- name: Wait for keycloak-operator CRDs to be established
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: "{{ item }}"
+    kubeconfig: /share/kubeconfig
+  register: _keycloak_operator_crd
+  until: >-
+    _keycloak_operator_crd.resources | length > 0 and
+    (_keycloak_operator_crd.resources[0].status.conditions | default([])
+     | selectattr('type', 'equalto', 'Established')
+     | selectattr('status', 'equalto', 'True') | list | length) > 0
+  retries: 20
+  delay: 5
+  loop: "{{ keycloak_operator_crd_names }}"

--- a/roles/keycloak_operator/tasks/main.yml
+++ b/roles/keycloak_operator/tasks/main.yml
@@ -3,6 +3,10 @@
   ansible.builtin.include_tasks: config.yml
   tags: config
 
+- name: Include crds tasks
+  ansible.builtin.include_tasks: crds.yml
+  tags: crds
+
 - name: Include namespace tasks
   ansible.builtin.include_tasks: namespace.yml
   tags: namespace


### PR DESCRIPTION
Apply the Keycloak CRDs that the role already ships, so `osism apply k8s-keycloak-operator`
produces a working operator on a cluster that has never had Keycloak.

### The problem

The role ships both CRDs in `roles/keycloak_operator/files/`:

- `keycloaks.k8s.keycloak.org-v1.yml` (~205 KB)
- `keycloakrealmimports.k8s.keycloak.org-v1.yml` (~176 KB)

but **no task ever applies them**. `tasks/main.yml` runs `config` → `namespace` → `deploy`,
and `deploy.yml` applies only the rendered `keycloak-operator.yml`. The separate `crds` role
covers only the prometheus-operator CRDs — `roles/crds/tasks/main.yml` contains a single task,
gated on `crds_prometheus_operator`.

So on a cluster where the CRDs are not already present, the play installs an operator with
nothing to reconcile.

### What this changes

- adds `roles/keycloak_operator/tasks/crds.yml`, included from `tasks/main.yml` before
  `namespace` and `deploy` so the CRDs exist by the time the operator starts
- waits for both CRDs to report `Established`
- adds `keycloak_operator_crd_directory`, `keycloak_operator_crds` and
  `keycloak_operator_crd_names` to the role defaults, so the file list is not hardcoded in the
  task

### Note on server-side apply

`crds.yml` uses `server_side_apply` rather than a plain apply. At this size a client-side
apply stores the entire object in the `kubectl.kubernetes.io/last-applied-configuration`
annotation, which exceeds the metadata size limit and fails. This is the standard approach
for large CRDs.

### Evidence

Verified on a k3s 1.36.3 cluster with no prior Keycloak installation:

- before: `osism apply k8s-keycloak-operator` leaves the operator running with no
  `keycloaks.k8s.keycloak.org` CRD present
- after: both CRDs reach `Established`, the operator reaches `1/1 Running`, and a `Keycloak`
  custom resource reconciles to `Ready=True` with a working instance behind it

`ansible-lint roles/keycloak_operator/` reports the same single pre-existing
`schema[meta]` violation before and after this change (an unrelated `meta/main.yml` platform
schema issue) — no new violations are introduced.

### Related

The role deploys only the operator: no `Keycloak` CR, no database, no TLS and no Service, all
of which are needed for a usable Keycloak. That is arguably out of scope for this role, but
worth either documenting or covering with an opinionated example. Happy to follow up
separately if useful.